### PR TITLE
Const _: () is not evaluated

### DIFF
--- a/bitfield-assertion/demo/impl/src/lib.rs
+++ b/bitfield-assertion/demo/impl/src/lib.rs
@@ -16,9 +16,8 @@ pub fn bitfield(_args: TokenStream, input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         fn __bitfield() {
-            let _: bitfield::MultipleOfEight<
-                [(); (0 #(+ <#fields as bitfield::Field>::BITS)*) % 8]
-            >;
+            const _: () = [()][(0 #(+ <#fields as bitfield::Field>::BITS)*) % 8];
+            const _: () = panic!("Hello world at compile-time!");
         }
     })
 }

--- a/bitfield-assertion/demo/main.rs
+++ b/bitfield-assertion/demo/main.rs
@@ -1,3 +1,5 @@
+#![feature(const_panic, underscore_const_names)]
+
 use bitfield::*;
 
 #[bitfield] // (1+3+4+23)%8 != 0


### PR DESCRIPTION
Ref #1. Try `cargo check` and observe that this code compiles successfully despite the assertions being violated. Both generated consts are visible in the output of `cargo expand`.

```rust
#![feature(prelude_import)]
#![no_std]
#![feature(const_panic, underscore_const_names)]
#[prelude_import]
use ::std::prelude::v1::*;
#[macro_use]
extern crate std as std;
use bitfield::*;
fn __bitfield() {
    const _: () = [()][(0
        + <B1 as bitfield::Field>::BITS
        + <B3 as bitfield::Field>::BITS
        + <B4 as bitfield::Field>::BITS
        + <B23 as bitfield::Field>::BITS)
        % 8];
    const _: () = {
        ::std::rt::begin_panic(
            "Hello world at compile-time!",
            &("bitfield-assertion/demo/main.rs", 5u32, 1u32),
        )
    };
}
fn main() {}
```